### PR TITLE
chore(samples): add samples for custom infotype rules

### DIFF
--- a/samples/snippets/custom_infotype.py
+++ b/samples/snippets/custom_infotype.py
@@ -17,6 +17,7 @@ This file contains sample code that uses the Data Loss Prevention API to create
 custom infoType detectors to refine scan results.
 """
 
+
 # [START dlp_inspect_string_with_exclusion_dict]
 def inspect_string_with_exclusion_dict(
     project, content_string, exclusion_list=["example@example.com"]

--- a/samples/snippets/custom_infotype.py
+++ b/samples/snippets/custom_infotype.py
@@ -17,6 +17,89 @@ This file contains sample code that uses the Data Loss Prevention API to create
 custom infoType detectors to refine scan results.
 """
 
+# [START dlp_inspect_string_with_exclusion_dict]
+def inspect_string_with_exclusion_dict(
+    project, content_string, exclusion_list=["example@example.com"]
+):
+    """Inspects the provided text, avoiding matches specified in the exclusion list
+
+    Uses the Data Loss Prevention API to omit matches on EMAIL_ADDRESS if they are
+    in the specified exclusion list.
+
+    Args:
+        project: The Google Cloud project id to use as a parent resource.
+        content_string: The string to inspect.
+        exclusion_list: The list of strings to ignore matches on
+
+    Returns:
+        None; the response from the API is printed to the terminal.
+    """
+
+    # Import the client library.
+    import google.cloud.dlp
+
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Construct a list of infoTypes for DLP to locate in `content_string`. See
+    # https://cloud.google.com/dlp/docs/concepts-infotypes for more information
+    # about supported infoTypes.
+    info_types_to_locate = [{"name": "EMAIL_ADDRESS"}]
+
+    # Construct a rule set that will only match on EMAIL_ADDRESS
+    # if the match text is not in the exclusion list.
+    rule_set = [
+        {
+            "info_types": info_types_to_locate,
+            "rules": [
+                {
+                    "exclusion_rule": {
+                        "dictionary": {
+                            "word_list": {
+                                "words": exclusion_list
+                            },
+                        },
+                        "matching_type": google.cloud.dlp_v2.MatchingType.MATCHING_TYPE_FULL_MATCH,
+                    }
+                }
+            ],
+        }
+    ]
+
+    # Construct the configuration dictionary
+    inspect_config = {
+        "info_types": info_types_to_locate,
+        "rule_set": rule_set,
+        "include_quote": True,
+    }
+
+    # Construct the `item`.
+    item = {"value": content_string}
+
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}"
+
+    # Call the API.
+    response = dlp.inspect_content(
+        request={"parent": parent, "inspect_config": inspect_config, "item": item}
+    )
+
+    # Print out the results.
+    if response.result.findings:
+        for finding in response.result.findings:
+            try:
+                if finding.quote:
+                    print(f"Quote: {finding.quote}")
+            except AttributeError:
+                pass
+            print(f"Info type: {finding.info_type.name}")
+            print(f"Likelihood: {finding.likelihood}")
+    else:
+        print("No findings.")
+
+# [END dlp_inspect_string_with_exclusion_dict]
+
+
 # [START dlp_inspect_string_with_exclusion_regex]
 def inspect_string_with_exclusion_regex(
     project, content_string, exclusion_regex=".+@example.com"

--- a/samples/snippets/custom_infotype.py
+++ b/samples/snippets/custom_infotype.py
@@ -393,7 +393,7 @@ def inspect_string_custom_excluding_substring(
         }
     ]
 
-    # Construct the configuration dictionary with the custom regex info type.
+    # Construct the configuration dictionary
     inspect_config = {
         "custom_info_types": custom_info_types,
         "rule_set": rule_set,
@@ -425,6 +425,92 @@ def inspect_string_custom_excluding_substring(
         print("No findings.")
 
 # [END dlp_inspect_string_custom_excluding_substring]
+
+
+# [START dlp_inspect_string_custom_omit_overlap]
+def inspect_string_custom_omit_overlap(
+    project, content_string
+):
+    """Matches PERSON_NAME and a custom detector,
+    but if they overlap only matches the custom detector
+
+    Uses the Data Loss Prevention API to omit matches on a built-in detector
+    if they overlap with matches from a custom detector
+
+    Args:
+        project: The Google Cloud project id to use as a parent resource.
+        content_string: The string to inspect.
+
+    Returns:
+        None; the response from the API is printed to the terminal.
+    """
+
+    # Import the client library.
+    import google.cloud.dlp
+
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Construct a custom regex detector for names
+    custom_info_types = [
+        {
+            "info_type": {"name": "VIP_DETECTOR"},
+            "regex": {"pattern": "Larry Page|Sergey Brin"},
+            "exclusion_type": google.cloud.dlp_v2.CustomInfoType.ExclusionType.EXCLUSION_TYPE_EXCLUDE,
+        }
+    ]
+
+    # Construct a rule set that will exclude PERSON_NAME matches
+    # that overlap with VIP_DETECTOR matches
+    rule_set = [
+        {
+            "info_types": [{"name": "PERSON_NAME"}],
+            "rules": [
+                {
+                    "exclusion_rule": {
+                        "exclude_info_types": {
+                            "info_types": [{"name": "VIP_DETECTOR"}]
+                        },
+                        "matching_type": google.cloud.dlp_v2.MatchingType.MATCHING_TYPE_FULL_MATCH,
+                    }
+                }
+            ],
+        }
+    ]
+
+    # Construct the configuration dictionary
+    inspect_config = {
+        "info_types": [{"name": "PERSON_NAME"}],
+        "custom_info_types": custom_info_types,
+        "rule_set": rule_set,
+        "include_quote": True,
+    }
+
+    # Construct the `item`.
+    item = {"value": content_string}
+
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}"
+
+    # Call the API.
+    response = dlp.inspect_content(
+        request={"parent": parent, "inspect_config": inspect_config, "item": item}
+    )
+
+    # Print out the results.
+    if response.result.findings:
+        for finding in response.result.findings:
+            try:
+                if finding.quote:
+                    print(f"Quote: {finding.quote}")
+            except AttributeError:
+                pass
+            print(f"Info type: {finding.info_type.name}")
+            print(f"Likelihood: {finding.likelihood}")
+    else:
+        print("No findings.")
+
+# [END dlp_inspect_string_custom_omit_overlap]
 
 
 # [START inspect_with_person_name_w_custom_hotword]

--- a/samples/snippets/custom_infotype.py
+++ b/samples/snippets/custom_infotype.py
@@ -264,83 +264,6 @@ def inspect_string_with_exclusion_dict_substring(
 # [END dlp_inspect_string_with_exclusion_dict_substring]
 
 
-# [START dlp_omit_name_if_also_email]
-def omit_name_if_also_email(
-    project, content_string,
-):
-    """Matches PERSON_NAME and EMAIL_ADDRESS, but not both.
-
-    Uses the Data Loss Prevention API omit matches on PERSON_NAME if the
-    EMAIL_ADDRESS detector also matches.
-    Args:
-        project: The Google Cloud project id to use as a parent resource.
-        content_string: The string to inspect.
-
-    Returns:
-        None; the response from the API is printed to the terminal.
-    """
-
-    # Import the client library.
-    import google.cloud.dlp
-
-    # Instantiate a client.
-    dlp = google.cloud.dlp_v2.DlpServiceClient()
-
-    # Construct a list of infoTypes for DLP to locate in `content_string`. See
-    # https://cloud.google.com/dlp/docs/concepts-infotypes for more information
-    # about supported infoTypes.
-    info_types_to_locate = [{"name": "PERSON_NAME"}, {"name": "EMAIL_ADDRESS"}]
-
-    # Construct the configuration dictionary that will only match on PERSON_NAME
-    # if the EMAIL_ADDRESS doesn't also match. This configuration helps reduce
-    # the total number of findings when there is a large overlap between different
-    # infoTypes.
-    inspect_config = {
-        "info_types": info_types_to_locate,
-        "rule_set": [
-            {
-                "info_types": [{"name": "PERSON_NAME"}],
-                "rules": [
-                    {
-                        "exclusion_rule": {
-                            "exclude_info_types": {
-                                "info_types": [{"name": "EMAIL_ADDRESS"}]
-                            },
-                            "matching_type": google.cloud.dlp_v2.MatchingType.MATCHING_TYPE_PARTIAL_MATCH,
-                        }
-                    }
-                ],
-            }
-        ],
-    }
-
-    # Construct the `item`.
-    item = {"value": content_string}
-
-    # Convert the project id into a full resource id.
-    parent = f"projects/{project}"
-
-    # Call the API.
-    response = dlp.inspect_content(
-        request={"parent": parent, "inspect_config": inspect_config, "item": item}
-    )
-
-    # Print out the results.
-    if response.result.findings:
-        for finding in response.result.findings:
-            try:
-                if finding.quote:
-                    print(f"Quote: {finding.quote}")
-            except AttributeError:
-                pass
-            print(f"Info type: {finding.info_type.name}")
-            print(f"Likelihood: {finding.likelihood}")
-    else:
-        print("No findings.")
-
-# [END dlp_omit_name_if_also_email]
-
-
 # [START dlp_inspect_string_custom_excluding_substring]
 def inspect_string_custom_excluding_substring(
     project, content_string, exclusion_list=["jimmy"]
@@ -513,6 +436,86 @@ def inspect_string_custom_omit_overlap(
 # [END dlp_inspect_string_custom_omit_overlap]
 
 
+# [START dlp_omit_name_if_also_email]
+def omit_name_if_also_email(
+    project, content_string,
+):
+    """Matches PERSON_NAME and EMAIL_ADDRESS, but not both.
+
+    Uses the Data Loss Prevention API omit matches on PERSON_NAME if the
+    EMAIL_ADDRESS detector also matches.
+    Args:
+        project: The Google Cloud project id to use as a parent resource.
+        content_string: The string to inspect.
+
+    Returns:
+        None; the response from the API is printed to the terminal.
+    """
+
+    # Import the client library.
+    import google.cloud.dlp
+
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Construct a list of infoTypes for DLP to locate in `content_string`. See
+    # https://cloud.google.com/dlp/docs/concepts-infotypes for more information
+    # about supported infoTypes.
+    info_types_to_locate = [{"name": "PERSON_NAME"}, {"name": "EMAIL_ADDRESS"}]
+
+    # Construct the configuration dictionary that will only match on PERSON_NAME
+    # if the EMAIL_ADDRESS doesn't also match. This configuration helps reduce
+    # the total number of findings when there is a large overlap between different
+    # infoTypes.
+    inspect_config = {
+        "info_types": info_types_to_locate,
+        "rule_set": [
+            {
+                "info_types": [{"name": "PERSON_NAME"}],
+                "rules": [
+                    {
+                        "exclusion_rule": {
+                            "exclude_info_types": {
+                                "info_types": [{"name": "EMAIL_ADDRESS"}]
+                            },
+                            "matching_type": google.cloud.dlp_v2.MatchingType.MATCHING_TYPE_PARTIAL_MATCH,
+                        }
+                    }
+                ],
+            }
+        ],
+    }
+
+    # Construct the `item`.
+    item = {"value": content_string}
+
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}"
+
+    # Call the API.
+    response = dlp.inspect_content(
+        request={"parent": parent, "inspect_config": inspect_config, "item": item}
+    )
+
+    # Print out the results.
+    if response.result.findings:
+        for finding in response.result.findings:
+            try:
+                if finding.quote:
+                    print(f"Quote: {finding.quote}")
+            except AttributeError:
+                pass
+            print(f"Info type: {finding.info_type.name}")
+            print(f"Likelihood: {finding.likelihood}")
+    else:
+        print("No findings.")
+
+# [END dlp_omit_name_if_also_email]
+
+
+# TODO: dlp_inspect_string_without_overlap
+
+
 # [START inspect_with_person_name_w_custom_hotword]
 def inspect_with_person_name_w_custom_hotword(
     project, content_string, custom_hotword="patient"
@@ -585,6 +588,9 @@ def inspect_with_person_name_w_custom_hotword(
 
 
 # [END inspect_with_person_name_w_custom_hotword]
+
+
+# TODO: dlp_inspect_string_multiple_rules
 
 
 # [START dlp_inspect_with_medical_record_number_custom_regex_detector]

--- a/samples/snippets/custom_infotype.py
+++ b/samples/snippets/custom_infotype.py
@@ -181,6 +181,89 @@ def inspect_string_with_exclusion_regex(
 # [END dlp_inspect_string_with_exclusion_regex]
 
 
+# [START dlp_inspect_string_with_exclusion_dict_substring]
+def inspect_string_with_exclusion_dict_substring(
+    project, content_string, exclusion_list=["TEST"]
+):
+    """Inspects the provided text, avoiding matches that contain excluded tokens
+
+    Uses the Data Loss Prevention API to omit matches if they include tokens
+    in the specified exclusion list.
+
+    Args:
+        project: The Google Cloud project id to use as a parent resource.
+        content_string: The string to inspect.
+        exclusion_list: The list of strings to ignore partial matches on
+
+    Returns:
+        None; the response from the API is printed to the terminal.
+    """
+
+    # Import the client library.
+    import google.cloud.dlp
+
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Construct a list of infoTypes for DLP to locate in `content_string`. See
+    # https://cloud.google.com/dlp/docs/concepts-infotypes for more information
+    # about supported infoTypes.
+    info_types_to_locate = [{"name": "EMAIL_ADDRESS"}, {"name": "DOMAIN_NAME"}]
+
+    # Construct a rule set that will only match if the match text does not
+    # contains tokens from the exclusion list.
+    rule_set = [
+        {
+            "info_types": info_types_to_locate,
+            "rules": [
+                {
+                    "exclusion_rule": {
+                        "dictionary": {
+                            "word_list": {
+                                "words": exclusion_list
+                            },
+                        },
+                        "matching_type": google.cloud.dlp_v2.MatchingType.MATCHING_TYPE_PARTIAL_MATCH,
+                    }
+                }
+            ],
+        }
+    ]
+
+    # Construct the configuration dictionary
+    inspect_config = {
+        "info_types": info_types_to_locate,
+        "rule_set": rule_set,
+        "include_quote": True,
+    }
+
+    # Construct the `item`.
+    item = {"value": content_string}
+
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}"
+
+    # Call the API.
+    response = dlp.inspect_content(
+        request={"parent": parent, "inspect_config": inspect_config, "item": item}
+    )
+
+    # Print out the results.
+    if response.result.findings:
+        for finding in response.result.findings:
+            try:
+                if finding.quote:
+                    print(f"Quote: {finding.quote}")
+            except AttributeError:
+                pass
+            print(f"Info type: {finding.info_type.name}")
+            print(f"Likelihood: {finding.likelihood}")
+    else:
+        print("No findings.")
+
+# [END dlp_inspect_string_with_exclusion_dict_substring]
+
+
 # [START dlp_omit_name_if_also_email]
 def omit_name_if_also_email(
     project, content_string,

--- a/samples/snippets/custom_infotype.py
+++ b/samples/snippets/custom_infotype.py
@@ -513,7 +513,94 @@ def omit_name_if_also_email(
 # [END dlp_omit_name_if_also_email]
 
 
-# TODO: dlp_inspect_string_without_overlap
+# [START dlp_inspect_string_without_overlap]
+def inspect_string_without_overlap(
+    project, content_string
+):
+    """Matches EMAIL_ADDRESS and DOMAIN_NAME, but DOMAIN_NAME is omitted
+    if it overlaps with EMAIL_ADDRESS
+
+    Uses the Data Loss Prevention API to omit matches of one infotype
+    that overlap with another.
+
+    Args:
+        project: The Google Cloud project id to use as a parent resource.
+        content_string: The string to inspect.
+
+    Returns:
+        None; the response from the API is printed to the terminal.
+    """
+
+    # Import the client library.
+    import google.cloud.dlp
+
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Construct a list of infoTypes for DLP to locate in `content_string`. See
+    # https://cloud.google.com/dlp/docs/concepts-infotypes for more information
+    # about supported infoTypes.
+    info_types_to_locate = [{"name": "DOMAIN_NAME"}, {"name": "EMAIL_ADDRESS"}]
+
+    # Define a custom info type to exclude email addresses
+    custom_info_types = [
+        {
+            "info_type": {"name": "EMAIL_ADDRESS"},
+            "exclusion_type": google.cloud.dlp_v2.CustomInfoType.ExclusionType.EXCLUSION_TYPE_EXCLUDE,
+        }
+    ]
+
+    # Construct a rule set that will exclude DOMAIN_NAME matches
+    # that overlap with EMAIL_ADDRESS matches
+    rule_set = [
+        {
+            "info_types": [{"name": "DOMAIN_NAME"}],
+            "rules": [
+                {
+                    "exclusion_rule": {
+                        "exclude_info_types": {
+                            "info_types": [{"name": "EMAIL_ADDRESS"}]
+                        },
+                        "matching_type": google.cloud.dlp_v2.MatchingType.MATCHING_TYPE_PARTIAL_MATCH,
+                    }
+                }
+            ],
+        }
+    ]
+
+    # Construct the configuration dictionary
+    inspect_config = {
+        "info_types": info_types_to_locate,
+        "custom_info_types": custom_info_types,
+        "rule_set": rule_set,
+        "include_quote": True,
+    }
+
+    # Construct the `item`.
+    item = {"value": content_string}
+
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}"
+
+    # Call the API.
+    response = dlp.inspect_content(
+        request={"parent": parent, "inspect_config": inspect_config, "item": item}
+    )
+
+    # Print out the results.
+    if response.result.findings:
+        for finding in response.result.findings:
+            try:
+                if finding.quote:
+                    print(f"Quote: {finding.quote}")
+            except AttributeError:
+                pass
+            print(f"Info type: {finding.info_type.name}")
+            print(f"Likelihood: {finding.likelihood}")
+    else:
+        print("No findings.")
+
+# [END dlp_inspect_string_without_overlap]
 
 
 # [START inspect_with_person_name_w_custom_hotword]

--- a/samples/snippets/custom_infotype.py
+++ b/samples/snippets/custom_infotype.py
@@ -87,11 +87,7 @@ def inspect_string_with_exclusion_dict(
     # Print out the results.
     if response.result.findings:
         for finding in response.result.findings:
-            try:
-                if finding.quote:
-                    print(f"Quote: {finding.quote}")
-            except AttributeError:
-                pass
+            print(f"Quote: {finding.quote}")
             print(f"Info type: {finding.info_type.name}")
             print(f"Likelihood: {finding.likelihood}")
     else:
@@ -168,11 +164,7 @@ def inspect_string_with_exclusion_regex(
     # Print out the results.
     if response.result.findings:
         for finding in response.result.findings:
-            try:
-                if finding.quote:
-                    print(f"Quote: {finding.quote}")
-            except AttributeError:
-                pass
+            print(f"Quote: {finding.quote}")
             print(f"Info type: {finding.info_type.name}")
             print(f"Likelihood: {finding.likelihood}")
     else:
@@ -251,11 +243,7 @@ def inspect_string_with_exclusion_dict_substring(
     # Print out the results.
     if response.result.findings:
         for finding in response.result.findings:
-            try:
-                if finding.quote:
-                    print(f"Quote: {finding.quote}")
-            except AttributeError:
-                pass
+            print(f"Quote: {finding.quote}")
             print(f"Info type: {finding.info_type.name}")
             print(f"Likelihood: {finding.likelihood}")
     else:
@@ -337,11 +325,7 @@ def inspect_string_custom_excluding_substring(
     # Print out the results.
     if response.result.findings:
         for finding in response.result.findings:
-            try:
-                if finding.quote:
-                    print(f"Quote: {finding.quote}")
-            except AttributeError:
-                pass
+            print(f"Quote: {finding.quote}")
             print(f"Info type: {finding.info_type.name}")
             print(f"Likelihood: {finding.likelihood}")
     else:
@@ -423,11 +407,7 @@ def inspect_string_custom_omit_overlap(
     # Print out the results.
     if response.result.findings:
         for finding in response.result.findings:
-            try:
-                if finding.quote:
-                    print(f"Quote: {finding.quote}")
-            except AttributeError:
-                pass
+            print(f"Quote: {finding.quote}")
             print(f"Info type: {finding.info_type.name}")
             print(f"Likelihood: {finding.likelihood}")
     else:
@@ -485,6 +465,7 @@ def omit_name_if_also_email(
                 ],
             }
         ],
+        "include_quote": True,
     }
 
     # Construct the `item`.
@@ -501,11 +482,7 @@ def omit_name_if_also_email(
     # Print out the results.
     if response.result.findings:
         for finding in response.result.findings:
-            try:
-                if finding.quote:
-                    print(f"Quote: {finding.quote}")
-            except AttributeError:
-                pass
+            print(f"Quote: {finding.quote}")
             print(f"Info type: {finding.info_type.name}")
             print(f"Likelihood: {finding.likelihood}")
     else:
@@ -591,11 +568,7 @@ def inspect_string_without_overlap(
     # Print out the results.
     if response.result.findings:
         for finding in response.result.findings:
-            try:
-                if finding.quote:
-                    print(f"Quote: {finding.quote}")
-            except AttributeError:
-                pass
+            print(f"Quote: {finding.quote}")
             print(f"Info type: {finding.info_type.name}")
             print(f"Likelihood: {finding.likelihood}")
     else:
@@ -650,6 +623,7 @@ def inspect_with_person_name_w_custom_hotword(
     inspect_config = {
         "rule_set": rule_set,
         "min_likelihood": google.cloud.dlp_v2.Likelihood.VERY_LIKELY,
+        "include_quote": True,
     }
 
     # Construct the `item`.
@@ -666,11 +640,7 @@ def inspect_with_person_name_w_custom_hotword(
     # Print out the results.
     if response.result.findings:
         for finding in response.result.findings:
-            try:
-                if finding.quote:
-                    print(f"Quote: {finding.quote}")
-            except AttributeError:
-                pass
+            print(f"Quote: {finding.quote}")
             print(f"Info type: {finding.info_type.name}")
             print(f"Likelihood: {finding.likelihood}")
     else:
@@ -764,11 +734,7 @@ def inspect_string_multiple_rules(
     # Print out the results.
     if response.result.findings:
         for finding in response.result.findings:
-            try:
-                if finding.quote:
-                    print(f"Quote: {finding.quote}")
-            except AttributeError:
-                pass
+            print(f"Quote: {finding.quote}")
             print(f"Info type: {finding.info_type.name}")
             print(f"Likelihood: {finding.likelihood}")
     else:
@@ -812,6 +778,7 @@ def inspect_with_medical_record_number_custom_regex_detector(
     # Construct the configuration dictionary with the custom regex info type.
     inspect_config = {
         "custom_info_types": custom_info_types,
+        "include_quote": True,
     }
 
     # Construct the `item`.
@@ -828,11 +795,7 @@ def inspect_with_medical_record_number_custom_regex_detector(
     # Print out the results.
     if response.result.findings:
         for finding in response.result.findings:
-            try:
-                if finding.quote:
-                    print(f"Quote: {finding.quote}")
-            except AttributeError:
-                pass
+            print(f"Quote: {finding.quote}")
             print(f"Info type: {finding.info_type.name}")
             print(f"Likelihood: {finding.likelihood}")
     else:
@@ -894,6 +857,7 @@ def inspect_with_medical_record_number_w_custom_hotwords(
     inspect_config = {
         "custom_info_types": custom_info_types,
         "rule_set": rule_set,
+        "include_quote": True,
     }
 
     # Construct the `item`.
@@ -910,11 +874,7 @@ def inspect_with_medical_record_number_w_custom_hotwords(
     # Print out the results.
     if response.result.findings:
         for finding in response.result.findings:
-            try:
-                if finding.quote:
-                    print(f"Quote: {finding.quote}")
-            except AttributeError:
-                pass
+            print(f"Quote: {finding.quote}")
             print(f"Info type: {finding.info_type.name}")
             print(f"Likelihood: {finding.likelihood}")
     else:

--- a/samples/snippets/custom_infotype.py
+++ b/samples/snippets/custom_infotype.py
@@ -341,6 +341,92 @@ def omit_name_if_also_email(
 # [END dlp_omit_name_if_also_email]
 
 
+# [START dlp_inspect_string_custom_excluding_substring]
+def inspect_string_custom_excluding_substring(
+    project, content_string, exclusion_list=["jimmy"]
+):
+    """Inspects the provided text with a custom detector, avoiding matches on specific tokens
+
+    Uses the Data Loss Prevention API to omit matches on a custom detector
+    if they include tokens in the specified exclusion list.
+
+    Args:
+        project: The Google Cloud project id to use as a parent resource.
+        content_string: The string to inspect.
+        exclusion_list: The list of strings to ignore matches on
+
+    Returns:
+        None; the response from the API is printed to the terminal.
+    """
+
+    # Import the client library.
+    import google.cloud.dlp
+
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Construct a custom regex detector for names
+    custom_info_types = [
+        {
+            "info_type": {"name": "CUSTOM_NAME_DETECTOR"},
+            "regex": {"pattern": "[A-Z][a-z]{1,15}, [A-Z][a-z]{1,15}"},
+        }
+    ]
+
+    # Construct a rule set that will only match if the match text does not
+    # contains tokens from the exclusion list.
+    rule_set = [
+        {
+            "info_types": [{"name": "CUSTOM_NAME_DETECTOR"}],
+            "rules": [
+                {
+                    "exclusion_rule": {
+                        "dictionary": {
+                            "word_list": {
+                                "words": exclusion_list
+                            },
+                        },
+                        "matching_type": google.cloud.dlp_v2.MatchingType.MATCHING_TYPE_PARTIAL_MATCH,
+                    }
+                }
+            ],
+        }
+    ]
+
+    # Construct the configuration dictionary with the custom regex info type.
+    inspect_config = {
+        "custom_info_types": custom_info_types,
+        "rule_set": rule_set,
+        "include_quote": True,
+    }
+
+    # Construct the `item`.
+    item = {"value": content_string}
+
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}"
+
+    # Call the API.
+    response = dlp.inspect_content(
+        request={"parent": parent, "inspect_config": inspect_config, "item": item}
+    )
+
+    # Print out the results.
+    if response.result.findings:
+        for finding in response.result.findings:
+            try:
+                if finding.quote:
+                    print(f"Quote: {finding.quote}")
+            except AttributeError:
+                pass
+            print(f"Info type: {finding.info_type.name}")
+            print(f"Likelihood: {finding.likelihood}")
+    else:
+        print("No findings.")
+
+# [END dlp_inspect_string_custom_excluding_substring]
+
+
 # [START inspect_with_person_name_w_custom_hotword]
 def inspect_with_person_name_w_custom_hotword(
     project, content_string, custom_hotword="patient"

--- a/samples/snippets/custom_infotype_test.py
+++ b/samples/snippets/custom_infotype_test.py
@@ -100,7 +100,40 @@ def test_inspect_with_person_name_w_custom_hotword(capsys):
     assert "Likelihood: 5" in out
 
 
-# TODO: dlp_inspect_string_multiple_rules
+def test_inspect_string_multiple_rules_patient(capsys):
+    custom_infotype.inspect_string_multiple_rules(
+        GCLOUD_PROJECT, "patient name: Jane Doe"
+    )
+
+    out, _ = capsys.readouterr()
+    assert "Likelihood: 4" in out
+
+
+def test_inspect_string_multiple_rules_doctor(capsys):
+    custom_infotype.inspect_string_multiple_rules(
+        GCLOUD_PROJECT, "doctor: Jane Doe"
+    )
+
+    out, _ = capsys.readouterr()
+    assert "No findings" in out
+
+
+def test_inspect_string_multiple_rules_quasimodo(capsys):
+    custom_infotype.inspect_string_multiple_rules(
+        GCLOUD_PROJECT, "patient name: quasimodo"
+    )
+
+    out, _ = capsys.readouterr()
+    assert "No findings" in out
+
+
+def test_inspect_string_multiple_rules_redacted(capsys):
+    custom_infotype.inspect_string_multiple_rules(
+        GCLOUD_PROJECT, "name of patient: REDACTED"
+    )
+
+    out, _ = capsys.readouterr()
+    assert "No findings" in out
 
 
 def test_inspect_with_medical_record_number_custom_regex_detector(capsys):

--- a/samples/snippets/custom_infotype_test.py
+++ b/samples/snippets/custom_infotype_test.py
@@ -60,6 +60,16 @@ def test_omit_name_if_also_email(capsys):
     assert "Info type: PERSON_NAME" not in out
 
 
+def test_inspect_string_custom_excluding_substring(capsys):
+    custom_infotype.inspect_string_custom_excluding_substring(
+        GCLOUD_PROJECT, "Danger, Jimmy | Wayne, Bruce", ["Jimmy"]
+    )
+
+    out, _ = capsys.readouterr()
+    assert "Wayne, Bruce" in out
+    assert "Danger, Jimmy" not in out
+
+
 def test_inspect_with_person_name_w_custom_hotword(capsys):
     custom_infotype.inspect_with_person_name_w_custom_hotword(
         GCLOUD_PROJECT, "patient's name is John Doe.", "patient"

--- a/samples/snippets/custom_infotype_test.py
+++ b/samples/snippets/custom_infotype_test.py
@@ -70,6 +70,16 @@ def test_inspect_string_custom_excluding_substring(capsys):
     assert "Danger, Jimmy" not in out
 
 
+def test_inspect_string_custom_omit_overlap(capsys):
+    custom_infotype.inspect_string_custom_omit_overlap(
+        GCLOUD_PROJECT, "Larry Page and John Doe"
+    )
+
+    out, _ = capsys.readouterr()
+    assert "Larry Page" not in out
+    assert "John Doe" in out
+
+
 def test_inspect_with_person_name_w_custom_hotword(capsys):
     custom_infotype.inspect_with_person_name_w_custom_hotword(
         GCLOUD_PROJECT, "patient's name is John Doe.", "patient"

--- a/samples/snippets/custom_infotype_test.py
+++ b/samples/snippets/custom_infotype_test.py
@@ -38,6 +38,17 @@ def test_inspect_string_with_exclusion_regex(capsys):
     assert "ironman" in out
 
 
+def test_inspect_string_with_exclusion_dict_substring(capsys):
+    custom_infotype.inspect_string_with_exclusion_dict_substring(
+        GCLOUD_PROJECT, "bob@example.com TEST@example.com TEST.com", ["TEST"]
+    )
+
+    out, _ = capsys.readouterr()
+    assert "TEST@example.com" not in out
+    assert "TEST.com" not in out
+    assert "bob@example.com" in out
+
+
 def test_omit_name_if_also_email(capsys):
     custom_infotype.omit_name_if_also_email(
         GCLOUD_PROJECT, "alice@example.com"

--- a/samples/snippets/custom_infotype_test.py
+++ b/samples/snippets/custom_infotype_test.py
@@ -18,15 +18,25 @@ import custom_infotype
 
 GCLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
 
+def test_inspect_string_with_exclusion_regex(capsys):
+    custom_infotype.inspect_string_with_exclusion_regex(
+        GCLOUD_PROJECT, "alice@example.com, ironman@avengers.net", ".+@example.com"
+    )
+
+    out, _ = capsys.readouterr()
+    assert "alice" not in out
+    assert "ironman" in out
+
 
 def test_omit_name_if_also_email(capsys):
-    info_types = custom_infotype.omit_name_if_also_email(
+    custom_infotype.omit_name_if_also_email(
         GCLOUD_PROJECT, "alice@example.com"
     )
 
     # Ensure we found only EMAIL_ADDRESS, and not PERSON_NAME.
-    assert len(info_types) == 1
-    assert info_types[0] == "EMAIL_ADDRESS"
+    out, _ = capsys.readouterr()
+    assert "Info type: EMAIL_ADDRESS" in out
+    assert "Info type: PERSON_NAME" not in out
 
 
 def test_inspect_with_person_name_w_custom_hotword(capsys):

--- a/samples/snippets/custom_infotype_test.py
+++ b/samples/snippets/custom_infotype_test.py
@@ -18,6 +18,7 @@ import custom_infotype
 
 GCLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
 
+
 def test_inspect_string_with_exclusion_dict(capsys):
     custom_infotype.inspect_string_with_exclusion_dict(
         GCLOUD_PROJECT, "gary@example.com, example@example.com", ["example@example.com"]

--- a/samples/snippets/custom_infotype_test.py
+++ b/samples/snippets/custom_infotype_test.py
@@ -18,6 +18,16 @@ import custom_infotype
 
 GCLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
 
+def test_inspect_string_with_exclusion_dict(capsys):
+    custom_infotype.inspect_string_with_exclusion_dict(
+        GCLOUD_PROJECT, "gary@example.com, example@example.com", ["example@example.com"]
+    )
+
+    out, _ = capsys.readouterr()
+    assert "example@example.com" not in out
+    assert "gary@example.com" in out
+
+
 def test_inspect_string_with_exclusion_regex(capsys):
     custom_infotype.inspect_string_with_exclusion_regex(
         GCLOUD_PROJECT, "alice@example.com, ironman@avengers.net", ".+@example.com"

--- a/samples/snippets/custom_infotype_test.py
+++ b/samples/snippets/custom_infotype_test.py
@@ -80,7 +80,14 @@ def test_omit_name_if_also_email(capsys):
     assert "Info type: PERSON_NAME" not in out
 
 
-# TODO: dlp_inspect_string_without_overlap
+def test_inspect_string_without_overlap(capsys):
+    custom_infotype.inspect_string_without_overlap(
+        GCLOUD_PROJECT, "example.com is a domain, james@example.org is an email."
+    )
+
+    out, _ = capsys.readouterr()
+    assert "example.com" in out
+    assert "example.org" not in out
 
 
 def test_inspect_with_person_name_w_custom_hotword(capsys):

--- a/samples/snippets/custom_infotype_test.py
+++ b/samples/snippets/custom_infotype_test.py
@@ -49,17 +49,6 @@ def test_inspect_string_with_exclusion_dict_substring(capsys):
     assert "bob@example.com" in out
 
 
-def test_omit_name_if_also_email(capsys):
-    custom_infotype.omit_name_if_also_email(
-        GCLOUD_PROJECT, "alice@example.com"
-    )
-
-    # Ensure we found only EMAIL_ADDRESS, and not PERSON_NAME.
-    out, _ = capsys.readouterr()
-    assert "Info type: EMAIL_ADDRESS" in out
-    assert "Info type: PERSON_NAME" not in out
-
-
 def test_inspect_string_custom_excluding_substring(capsys):
     custom_infotype.inspect_string_custom_excluding_substring(
         GCLOUD_PROJECT, "Danger, Jimmy | Wayne, Bruce", ["Jimmy"]
@@ -80,6 +69,20 @@ def test_inspect_string_custom_omit_overlap(capsys):
     assert "John Doe" in out
 
 
+def test_omit_name_if_also_email(capsys):
+    custom_infotype.omit_name_if_also_email(
+        GCLOUD_PROJECT, "alice@example.com"
+    )
+
+    # Ensure we found only EMAIL_ADDRESS, and not PERSON_NAME.
+    out, _ = capsys.readouterr()
+    assert "Info type: EMAIL_ADDRESS" in out
+    assert "Info type: PERSON_NAME" not in out
+
+
+# TODO: dlp_inspect_string_without_overlap
+
+
 def test_inspect_with_person_name_w_custom_hotword(capsys):
     custom_infotype.inspect_with_person_name_w_custom_hotword(
         GCLOUD_PROJECT, "patient's name is John Doe.", "patient"
@@ -88,6 +91,9 @@ def test_inspect_with_person_name_w_custom_hotword(capsys):
     out, _ = capsys.readouterr()
     assert "Info type: PERSON_NAME" in out
     assert "Likelihood: 5" in out
+
+
+# TODO: dlp_inspect_string_multiple_rules
 
 
 def test_inspect_with_medical_record_number_custom_regex_detector(capsys):


### PR DESCRIPTION
Add missing python samples for https://cloud.google.com/dlp/docs/creating-custom-infotypes-rules#dlp_inspect_string_without_overlap-java

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-dlp/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
  - Some tests in other files are already broken, but `pytest custom_infotype_test.py` succeeds. 
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)



Fixes internal bugs:
b/156968601
b/156970772
b/156970547
b/156969966
b/156970576
b/156974339
b/156969968
