### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "dlp",
     "name_pretty": "Cloud Data Loss Prevention",
     "product_documentation": "https://cloud.google.com/dlp/docs/",
-    "client_documentation": "https://googleapis.dev/python/dlp/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/dlp/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ storage repositories.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dlp.svg
    :target: https://pypi.org/project/google-cloud-dlp/
 .. _Cloud Data Loss Prevention (DLP) API: https://cloud.google.com/dlp
-.. _Client Library Documentation: https://googleapis.dev/python/dlp/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/dlp/latest
 .. _Product Documentation:  https://cloud.google.com/dlp
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.