### PR TITLE
fix: Use unittest.mock if available

### DIFF
--- a/tests/unit/gapic/dlp_v2/test_dlp_service.py
+++ b/tests/unit/gapic/dlp_v2/test_dlp_service.py
@@ -33,7 +33,10 @@ from google.type import dayofweek_pb2  # type: ignore
 from google.type import timeofday_pb2  # type: ignore
 import grpc
 from grpc.experimental import aio
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from proto.marshal.rules.dates import DurationRule, TimestampRule
 import pytest
 


### PR DESCRIPTION
The `mock` module is deprecated in recent Python versions.

Signed-off-by: Major Hayden <major@mhtx.net>

Fixes #389 🦕
