### PR TITLE
fix(deps): require protobuf <4.0.0dev

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ dependencies = [
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566
     "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
-    "proto-plus >= 1.15.0",
-    "pytz >= 2021.1",
+    "proto-plus >= 1.15.0, <2.0.0dev",
+    "protobuf >= 3.19.0, <4.0.0dev",
 ]
 
 extras = {"libcst": "libcst >= 0.2.5"}

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -8,3 +8,4 @@
 google-api-core==1.31.5
 proto-plus==1.15.0
 libcst==0.2.5
+protobuf==3.19.0


### PR DESCRIPTION
Towards b/234444818

fix: drop dependency pytz